### PR TITLE
feat: add validated date field for date of birth

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -182,6 +182,7 @@ label {
 input[type="email"],
 input[type="tel"],
 input[type="text"],
+input[type="date"],
 input[type="number"],
 input[type="password"] {
   padding: 0.65rem 0.5rem;
@@ -199,6 +200,7 @@ input[type="password"] {
   input[type="email"],
   input[type="tel"],
   input[type="text"],
+  input[type="date"],
   input[type="number"],
   input[type="password"] {
     background-color: var(--gray-800);
@@ -209,6 +211,7 @@ input[type="password"] {
   input[type="email"]::placeholder,
   input[type="tel"]::placeholder,
   input[type="text"]::placeholder,
+  input[type="date"]::placeholder,
   input[type="number"]::placeholder,
   input[type="password"]::placeholder,
   select,
@@ -220,6 +223,7 @@ input[type="password"] {
 input[type="email"],
 input[type="tel"],
 input[type="text"],
+input[type="date"],
 input[type="number"],
 input[type="password"],
 textarea,
@@ -640,6 +644,7 @@ button[type="reset"]:hover {
 input[type="email"],
 input[type="tel"],
 input[type="text"],
+input[type="date"],
 input[type="number"],
 input[type="password"]
 textarea,

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,16 @@ const MyTextArea = ({ label, ...props }) => {
   )
 }
 
+const calculateMaxValidDate = () => {
+  let date = new Date()
+  date = date.setFullYear(date.getFullYear() - 18)
+  date = new Date(date)
+  date = date.toISOString().slice(0, 10)
+  return date
+}
+
+const MAX_VALID_DATE = calculateMaxValidDate()
+
 const SignupForm = () => {
   return (
     <Formik
@@ -74,7 +84,8 @@ const SignupForm = () => {
         city: '',
         acceptedTerms: false,
         jobType: '',
-        cellphone: ''
+        cellphone: '',
+        dob: ''
       }}
       validationSchema={Yup.object({
         fullname: Yup
@@ -100,6 +111,16 @@ const SignupForm = () => {
           .matches(
             /^\d{5}-{0,1}\d{7}-{0,1}\d{1}$/,
             'Please follow patterns: 01234-1234567-8'
+          ),
+        dob: Yup
+          .date()
+          .required('Required')
+          .test(
+            'Should be less than current date',
+            'Please select a valid date',
+            value => {
+              return value < new Date(MAX_VALID_DATE)
+            }
           ),
         streetAddress: Yup.string().required('Required'),
         cellphone: Yup.string().required('Required')
@@ -140,6 +161,13 @@ const SignupForm = () => {
             name='cnic'
             placeholder='01234-1234567-8'
             type='text'
+          />
+
+          <MyTextInput
+            label='Date of Birth'
+            name='dob'
+            type='date'
+            max={MAX_VALID_DATE}
           />
 
           <MyTextInput


### PR DESCRIPTION
Closes #1 

## About this PR
This PR will add a date field for date-of-birth. This field will ensure that the input date is 18 years old from the current date. This kind of validation is used in sites, that allow only users greater than 18 years.